### PR TITLE
Add automatic module names via manifest

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,6 +26,10 @@
     <artifactId>jpaseto-api</artifactId>
     <name>JPaseto :: API</name>
 
+    <properties>
+        <module-name>dev.paseto.jpaseto.api</module-name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/extensions/crypto/bouncy-castle/pom.xml
+++ b/extensions/crypto/bouncy-castle/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>jpaseto-bouncy-castle</artifactId>
     <name>JPaseto :: Crypto :: Bouncy Castle</name>
 
+    <properties>
+        <module-name>dev.paseto.jpaseto.crypto.bouncycastle</module-name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.paseto</groupId>

--- a/extensions/crypto/hkdf/pom.xml
+++ b/extensions/crypto/hkdf/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>jpaseto-hkdf</artifactId>
     <name>JPaseto :: Crypto :: HKDF</name>
 
+    <properties>
+        <module-name>dev.paseto.jpaseto.crypto.hkdf</module-name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.paseto</groupId>

--- a/extensions/crypto/sodium/pom.xml
+++ b/extensions/crypto/sodium/pom.xml
@@ -25,7 +25,11 @@
     </parent>
 
     <artifactId>jpaseto-sodium</artifactId>
-    <name>JPaseto :: Crypto :: Jackson</name>
+    <name>JPaseto :: Crypto :: Sodium</name>
+
+    <properties>
+        <module-name>dev.paseto.jpaseto.crypto.sodium</module-name>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/extensions/json/gson/pom.xml
+++ b/extensions/json/gson/pom.xml
@@ -28,6 +28,10 @@
     <artifactId>jpaseto-gson</artifactId>
     <name>JPaseto :: JSON :: Gson</name>
 
+    <properties>
+        <module-name>dev.paseto.jpaseto.io.gson</module-name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.paseto</groupId>

--- a/extensions/json/jackson/pom.xml
+++ b/extensions/json/jackson/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>jpaseto-jackson</artifactId>
     <name>JPaseto :: JSON :: Jackson</name>
 
+    <properties>
+        <module-name>dev.paseto.jpaseto.io.jackson</module-name>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/fips-integration-tests/pom.xml
+++ b/fips-integration-tests/pom.xml
@@ -26,6 +26,10 @@
     <artifactId>jpaseto-its-fips</artifactId>
     <name>JPaseto :: ITs :: FIPS</name>
 
+    <properties>
+        <module-name>dev.paseto.jpaseto.fips.its</module-name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.paseto</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -27,6 +27,10 @@
     <name>JPaseto :: Impl</name>
     <description />
 
+    <properties>
+        <module-name>dev.paseto.jpaseto.impl</module-name>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -26,6 +26,10 @@
     <artifactId>jpaseto-its</artifactId>
     <name>JPaseto :: ITs</name>
 
+    <properties>
+        <module-name>dev.paseto.jpaseto.its</module-name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>dev.paseto</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,9 @@
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${module-name}</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Quick output of module names in manifest files
```
 find . | grep 0.7.0-SNAPSHOT.jar  | xargs -I{} unzip -c {}  META-INF/MANIFEST.MF | grep  'Archive\|Automatic'
Archive:  ./impl/target/jpaseto-impl-0.7.0-SNAPSHOT.jar
Automatic-Module-Name: dev.paseto.jpaseto.impl
Archive:  ./integration-tests/target/jpaseto-its-0.7.0-SNAPSHOT.jar
Automatic-Module-Name: dev.paseto.jpaseto.its
Archive:  ./extensions/crypto/hkdf/target/jpaseto-hkdf-0.7.0-SNAPSHOT.jar
Automatic-Module-Name: dev.paseto.jpaseto.crypto.hkdf
Archive:  ./extensions/crypto/bouncy-castle/target/jpaseto-bouncy-castle-0.7.0-SNAPSHOT.jar
Automatic-Module-Name: dev.paseto.jpaseto.crypto.bouncycastle
Archive:  ./extensions/crypto/sodium/target/jpaseto-sodium-0.7.0-SNAPSHOT.jar
Automatic-Module-Name: dev.paseto.jpaseto.crypto.sodium
Archive:  ./extensions/json/gson/target/jpaseto-gson-0.7.0-SNAPSHOT.jar
Automatic-Module-Name: dev.paseto.jpaseto.io.gson
Archive:  ./extensions/json/jackson/target/jpaseto-jackson-0.7.0-SNAPSHOT.jar
Automatic-Module-Name: dev.paseto.jpaseto.io.jackson
Archive:  ./fips-integration-tests/target/jpaseto-its-fips-0.7.0-SNAPSHOT.jar
Automatic-Module-Name: dev.paseto.jpaseto.fips.its
Archive:  ./api/target/jpaseto-api-0.7.0-SNAPSHOT.jar
Automatic-Module-Name: dev.paseto.jpaseto.api
```

<!--
For Security Vulnerabilities, please see https://github.com/paseto-toolkit/jpaseto/blob/master/SECURITY.md
-->