### PR TITLE
Adding pure Java support of V2 Local token types

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -32,3 +32,4 @@ This project includes:
 
 This project also includes modified code based on the following copyrights:
 - General project structure, parser, builder, JSON parsing, etc, JJWT. Apache 2.0 licensed.
+- XChaCha20Poly1305 from O(1) - https://github.com/o1c-dev Apache 2.0 licensed.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ registered date claims.
 
 The goal of this project is to provide a pure Java implementation of the Paseto specification. 
 
-**NOTE:** "v2.local" tokens currently require the use of a native library "libsodium", a pure java implementation will be 
-available in the future. (see below for more details)
-
 ## Table of Contents
 
 * [Features](#features)
@@ -80,7 +77,7 @@ Why choose this library over the other Java Paseto implementations?
 - Fluent API
 - Full security audited performed by [Paragon Initiative Enterprises](https://paragonie.com/audit/OiT6VlbQ7n6Y6Qz6)
 - Available on Maven Central
-- Low dependency count(with the exception of libsodium)
+- Low dependency count
 - Already using JJWT, this library works the same way
 
 <a name="community"></a>
@@ -218,7 +215,7 @@ If you're building a (non-Android) JDK project, you will want to define the foll
     <version>0.6.0</version>
     <scope>runtime</scope>
 </dependency>
-<!-- Uncomment the next lines if you want to use v1.local tokens -->
+<!-- Uncomment the next lines if you want to use Bouncy Castle, supports all Paseto formats -->
 <!-- 
 <dependency>
     <groupId>dev.paseto</groupId>
@@ -234,7 +231,7 @@ If you're building a (non-Android) JDK project, you will want to define the foll
     <version>0.6.0</version>
     <scope>runtime</scope>
 </dependency> -->
-<!-- Uncomment the next lines if you want to use v2 tokens -->
+<!-- Uncomment the next lines if you want to use Lib Sodium for v2 local tokens -->
 <!-- NOTE: this requires the native lib sodium library installed on your system see below -->
 <!-- 
 <dependency>
@@ -252,20 +249,23 @@ If you're building a (non-Android) JDK project, you will want to define the foll
 dependencies {
     compile 'dev.paseto:jpaseto-api:0.6.0'
     runtime 'dev.paseto:jpaseto-impl:0.6.0',
-            // Uncomment the next lines if you want to use v1.local tokens
-            // 'dev.paseto:jpaseto-bouncy-castle:0.6.0',
-            // or this (only 'v1.local' tokens) for smaller dependency (~11 KB for HKDF vs. ~4.3 MB for Bouncy Castle)
-            // 'dev.paseto:jpaseto-hkdf:0.6.0',
-            // Uncomment the next lines if you want to use v2 tokens
-            // NOTE: this requires the native lib sodium library installed on your system see below
-            // 'dev.paseto:jpaseto-sodium:0.6.0',
-            'dev.paseto:jpaseto-jackson:0.6.0'
+            'dev.paseto:jpaseto-jackson:0.6.0',
+
+          // Uncomment the next lines if you want to use Bouncy Castle, supports all Paseto formats
+          // 'dev.paseto:jpaseto-bouncy-castle:0.6.0',
+
+          // or this (only 'v1.local' tokens) for smaller dependency (~11 KB for HKDF vs. ~4.3 MB for Bouncy Castle)
+          // 'dev.paseto:jpaseto-hkdf:0.6.0',
+  
+          // Uncomment the next lines if you want to use Lib Sodium for v2 local tokens 
+          // NOTE: this requires the native lib sodium library installed on your system see below
+          // 'dev.paseto:jpaseto-sodium:0.6.0', // supports v2 local tokens
 }
 ```
 <a name="install-sodium"></a>
 #### libsodium
 
-Installation the a native library [libsodium](https://github.com/jedisct1/libsodium) is required when creating or parseing "v2.local" tokens.
+Installation the a native library [libsodium](https://github.com/jedisct1/libsodium) is required when creating or parseing "v2.local" tokens, as an alternative to using `jpaseto-bouncy-castle`.
 
 **NOTE:** `public` tokens can be used with the `jpaseto-bouncy-castle` dependency or Java 11+. `v1.local` tokens require `jpaseto-bouncy-castle` or `jpaseto-hkdf`.
 
@@ -283,13 +283,13 @@ All Paseto formats are supported by JPaseto, the following contains a table of w
 | Module (Artifact Id) | Description | v1.local | v1.public | v2.local | v2.public |
 | -------------------- | ----------- | -------- | --------- | -------- | --------- |
 | no additional modules <sup>*</sup> | [Java Cryptography Architecture (JCA)](https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html) | ❌ | ✅ | ❌ | ✅ |
-| `jpaseto-bouncy-castle` | [Bouncy Castle](https://www.bouncycastle.org/) | ✅ | ✅ | ❌ | ✅ | 
+| `jpaseto-bouncy-castle` | [Bouncy Castle](https://www.bouncycastle.org/) | ✅ | ✅ | ✅ | ✅ | 
 | `jpaseto-hkdf` | [HKDF](https://github.com/patrickfav/hkdf), minimal dependency size (~11K),  | ✅ | ❌ | ❌ | ❌ |
 | `jpaseto-sodium` | [https://libsodium.gitbook.io/doc/](https://libsodium.gitbook.io/doc/) | ❌ | ❌ | ✅ | ❌ |  
 
 <sup>*</sup> With no additional dependencies `v1.public` and `v2.public` tokens are supported with via the [Java Cryptography Architecture (JCA)](https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html) API. Generally speaking, without the additional modules listed above `v1.public` tokens require [Java 11 (and some Java 8 distributions)](https://bugs.openjdk.java.net/browse/JDK-8230978), and `v2.public` tokens require [Java 15](https://bugs.openjdk.java.net/browse/JDK-8190219).
 
-**NOTE:** Multiple implementations can be used together, for example using `jpaseto-bouncy-castle` and `jpaseto-sodium` on a 1.8+ JVM would support all token types. 
+**NOTE:** Multiple implementations can be used together, for example using `jpaseto-hkdf` and `jpaseto-sodium` on a 1.8+ JVM would support all token types. 
 
 <a name="install-understandingdependencies"></a>
 ### Understanding JPaseto Dependencies

--- a/extensions/crypto/bouncy-castle/src/main/java/dev/paseto/jpaseto/crypto/bouncycastle/BouncyCastleV2LocalCryptoProvider.java
+++ b/extensions/crypto/bouncy-castle/src/main/java/dev/paseto/jpaseto/crypto/bouncycastle/BouncyCastleV2LocalCryptoProvider.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020-Present paseto.dev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.paseto.jpaseto.crypto.bouncycastle;
+
+import com.google.auto.service.AutoService;
+import dev.paseto.jpaseto.PasetoSecurityException;
+import dev.paseto.jpaseto.impl.crypto.PreAuthEncoder;
+import dev.paseto.jpaseto.impl.crypto.V2LocalCryptoProvider;
+import dev.paseto.jpaseto.impl.lang.Bytes;
+import org.bouncycastle.crypto.digests.Blake2bDigest;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+@AutoService(V2LocalCryptoProvider.class)
+public class BouncyCastleV2LocalCryptoProvider implements V2LocalCryptoProvider {
+
+    private static final byte[] HEADER_BYTES = "v2.local.".getBytes(StandardCharsets.UTF_8);
+
+    @Override
+    public byte[] blake2b(byte[] payload, byte[] random) {
+        byte[] hash = new byte[24];
+        Blake2bDigest digest = new Blake2bDigest(random, 24, null, null);
+        digest.update(payload, 0, payload.length);
+        digest.doFinal(hash, 0);
+        return hash;
+    }
+
+    @Override
+    public byte[] encrypt(byte[] payload, byte[] footer, byte[] nonce, SecretKey sharedSecret) {
+        // 4
+        byte[] preAuth = PreAuthEncoder.encode(HEADER_BYTES, nonce, footer);
+
+        byte[] payloadCipher;
+        try {
+            // 5
+            Cipher cipher = XChaCha20Poly1305.cryptWith(true, sharedSecret.getEncoded(), nonce, preAuth);
+            payloadCipher = cipher.doFinal(payload);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new PasetoSecurityException("Failed to encrypt token", e);
+        }
+
+        // 6
+        return Bytes.concat(nonce, payloadCipher);
+    }
+
+    @Override
+    public byte[] decrypt(byte[] encryptedBytes, byte[] footer, SecretKey sharedSecret) {
+        byte[] nonce = Arrays.copyOf(encryptedBytes, 24); // nonce size is 24 bytes
+        byte[] encryptedMessage = Arrays.copyOfRange(encryptedBytes, 24, encryptedBytes.length);
+        byte[] preAuth = PreAuthEncoder.encode(HEADER_BYTES, nonce, footer);
+
+        byte[] payloadBytes;
+        try {
+            // 5
+            Cipher cipher = XChaCha20Poly1305.cryptWith(false, sharedSecret.getEncoded(), nonce, preAuth);
+            payloadBytes = cipher.doFinal(encryptedMessage);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new PasetoSecurityException("Decryption failed, likely cause is an invalid sharedSecret or MAC.", e);
+        }
+
+        return payloadBytes;
+    }
+}

--- a/extensions/crypto/bouncy-castle/src/main/java/dev/paseto/jpaseto/crypto/bouncycastle/XChaCha20Poly1305.java
+++ b/extensions/crypto/bouncy-castle/src/main/java/dev/paseto/jpaseto/crypto/bouncycastle/XChaCha20Poly1305.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Matt Sicker
+ * Modifications Copyright 2020-Present paseto.dev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.paseto.jpaseto.crypto.bouncycastle;
+
+import org.bouncycastle.util.Arrays;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * A Java implementation of XChaCha20Poly1305 using Bouncy Castle.
+ * Adapted from: https://github.com/o1c-dev/o1c/blob/567a420aacb4c41b415e0413a4b347ec416bb7e9/java8/src/main/java/dev/o1c/spi/XChaCha20Poly1305.java
+ * @see <a href="https://tools.ietf.org/html/rfc8439">rfc8439</a>
+ * @see <a href="https://tools.ietf.org/html/draft-irtf-cfrg-xchacha-03">draft rfc xchacha</a>
+ */
+final class XChaCha20Poly1305 {
+    private static final int KEY_SIZE = 32;
+    private static final int[] ENGINE_STATE_HEADER = unpackIntsLE("expand 32-byte k".getBytes(StandardCharsets.US_ASCII), 0, 4);
+
+    private XChaCha20Poly1305() {}
+
+    static Cipher cryptWith(boolean forEncryption, byte[] key, byte[] nonce, byte[] aad) {
+        Cipher cipher = getChaCha20Poly1305();
+        byte[] hNonce = Arrays.copyOfRange(nonce, 0, 16);
+        byte[] sNonce = Arrays.copyOfRange(nonce, 12, nonce.length);
+        packIntLE(0, sNonce, 0);
+        SecretKey subkey = new SecretKeySpec(calculateSubKey(key, hNonce), "XChaCha20-Poly1305");
+        IvParameterSpec iv = new IvParameterSpec(sNonce);
+        try {
+            cipher.init(forEncryption ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE, subkey, iv);
+            cipher.updateAAD(aad);
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+            throw new IllegalStateException(e);
+        }
+        return cipher;
+    }
+
+    static byte[] calculateSubKey(byte[] key, byte[] nonce) {
+        int[] state = Arrays.copyOf(ENGINE_STATE_HEADER, 16);
+        unpackIntsLE(key, 0, 8, state, 4);
+        unpackIntsLE(nonce, 0, 4, state, 12);
+        chaChaBlock(state);
+        byte[] subkey = new byte[KEY_SIZE];
+        packIntsLE(state, 0, 4, subkey, 0);
+        packIntsLE(state, 12, 4, subkey, 16);
+        return subkey;
+    }
+
+    private static void chaChaBlock(int[] state) {
+        for (int i = 0; i < 10; i++) {
+            columnRound(state);
+            diagonalRound(state);
+        }
+    }
+
+    private static void columnRound(int[] state) {
+        quarterRound(state, 0, 4, 8, 12);
+        quarterRound(state, 1, 5, 9, 13);
+        quarterRound(state, 2, 6, 10, 14);
+        quarterRound(state, 3, 7, 11, 15);
+    }
+
+    private static void diagonalRound(int[] state) {
+        quarterRound(state, 0, 5, 10, 15);
+        quarterRound(state, 1, 6, 11, 12);
+        quarterRound(state, 2, 7, 8, 13);
+        quarterRound(state, 3, 4, 9, 14);
+    }
+
+    private static void quarterRound(int[] state, int a, int b, int c, int d) {
+        state[a] += state[b];
+        state[d] = shiftLeftRotate(state[d] ^ state[a], 16);
+
+        state[c] += state[d];
+        state[b] = shiftLeftRotate(state[b] ^ state[c], 12);
+
+        state[a] += state[b];
+        state[d] = shiftLeftRotate(state[d] ^ state[a], 8);
+
+        state[c] += state[d];
+        state[b] = shiftLeftRotate(state[b] ^ state[c], 7);
+    }
+
+    // val <<< len
+    private static int shiftLeftRotate(int val, int len) {
+        return (val << len) | (val >>> -len);
+    }
+
+    private static Cipher getChaCha20Poly1305() {
+        try {
+            return Cipher.getInstance("ChaCha20-Poly1305");
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void packIntLE(int value, byte[] dst, int off) {
+        dst[off] = (byte) value;
+        dst[off + 1] = (byte) (value >>> 8);
+        dst[off + 2] = (byte) (value >>> 16);
+        dst[off + 3] = (byte) (value >>> 24);
+    }
+
+    private static void packIntsLE(int[] values, int off, int nrInts, byte[] dst, int dstOff) {
+        for (int i = 0; i < nrInts; i++) {
+            packIntLE(values[off + i], dst, dstOff + i * 4);
+        }
+    }
+
+    private static int unpackIntLE(byte[] buf, int off) {
+        return buf[off] & 0xff | (buf[off + 1] & 0xff) << 8 | (buf[off + 2] & 0xff) << 16 | (buf[off + 3] & 0xff) << 24;
+    }
+
+    private static void unpackIntsLE(byte[] buf, int off, int nrInts, int[] dst, int dstOff) {
+        for (int i = 0; i < nrInts; i++) {
+            dst[dstOff + i] = unpackIntLE(buf, off + i * 4);
+        }
+    }
+
+    private static int[] unpackIntsLE(byte[] buf, int off, int nrInts) {
+        int[] values = new int[nrInts];
+        unpackIntsLE(buf, off, nrInts, values, 0);
+        return values;
+    }
+}

--- a/extensions/crypto/bouncy-castle/src/test/groovy/dev/paseto/jpaseto/crypto/bouncycastle/BouncyCastleV2LocalIT.groovy
+++ b/extensions/crypto/bouncy-castle/src/test/groovy/dev/paseto/jpaseto/crypto/bouncycastle/BouncyCastleV2LocalIT.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020-Present paseto.dev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.paseto.jpaseto.crypto.bouncycastle
+
+import dev.paseto.jpaseto.its.V2LocalIT
+
+class BouncyCastleV2LocalIT extends V2LocalIT {}

--- a/extensions/crypto/bouncy-castle/src/test/groovy/dev/paseto/jpaseto/crypto/bouncycastle/BouncyCastleV2PublicCryptoProviderTest.groovy
+++ b/extensions/crypto/bouncy-castle/src/test/groovy/dev/paseto/jpaseto/crypto/bouncycastle/BouncyCastleV2PublicCryptoProviderTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020-Present paseto.dev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.paseto.jpaseto.crypto.bouncycastle
+
+import org.testng.annotations.Test
+
+import static org.hamcrest.Matchers.is
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.bouncycastle.util.encoders.Hex.decode
+
+class BouncyCastleV2PublicCryptoProviderTest {
+    @Test
+    void blake2bTest() {
+        // test vector with a 24 hash length
+        def payload = decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
+        def key = decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f")
+        def expectedHash = decode("46cbab86d3dd2e34f925259a0cf69cc92cf48f094cecd403")
+
+        def result = new BouncyCastleV2LocalCryptoProvider().blake2b(payload, key)
+        assertThat result, is(expectedHash)
+    }
+}

--- a/extensions/crypto/bouncy-castle/src/test/groovy/dev/paseto/jpaseto/crypto/bouncycastle/XChaCha20Poly1305Test.groovy
+++ b/extensions/crypto/bouncy-castle/src/test/groovy/dev/paseto/jpaseto/crypto/bouncycastle/XChaCha20Poly1305Test.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Matt Sicker
+ * Modifications Copyright 2020-Present paseto.dev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.paseto.jpaseto.crypto.bouncycastle
+
+import org.testng.annotations.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.equalTo
+import static org.bouncycastle.util.encoders.Hex.decode
+
+class XChaCha20Poly1305Test {
+
+    @Test
+    void subkeyDerivation() {
+        def key = decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+        def nonce = decode("000000090000004a0000000031415927")
+        def expectedKey = decode("82413b4227b27bfed30e42508a877d73a0f9e4d58a74a853c12ec41326d3ecdc")
+        def actualKey = XChaCha20Poly1305.calculateSubKey(key, nonce)
+        assertThat expectedKey, equalTo(actualKey)
+    }
+}

--- a/src/license/NOTICE.template
+++ b/src/license/NOTICE.template
@@ -17,3 +17,4 @@ This project includes:
 
 This project also includes modified code based on the following copyrights:
 - General project structure, parser, builder, JSON parsing, etc, JJWT. Apache 2.0 licensed.
+- XChaCha20Poly1305 from O(1) - https://github.com/o1c-dev Apache 2.0 licensed.

--- a/src/spotbugs/spotbugs-exclude.xml
+++ b/src/spotbugs/spotbugs-exclude.xml
@@ -53,6 +53,13 @@
     </Match>
 
     <Match>
+        <!-- XChaCha20Poly1305 has an Additional Authentication Data (AAD)
+             This value is passed into the method that constructs the cipher to prevent accidental misuse -->
+        <Class name="dev.paseto.jpaseto.crypto.bouncycastle.XChaCha20Poly1305"/>
+        <Bug pattern="CIPHER_INTEGRITY"/>
+    </Match>
+
+    <Match>
         <!-- SpotBugs doesn't deal with Groovy well -->
         <!-- NOTE: normally test classes are skipped anyway, but they are exposed here to be reused in other modules -->
         <Package name="dev.paseto.jpaseto.its" />


### PR DESCRIPTION
* Support for libsodium may be removed in the future
* Updated README to mention v2.local support with the Bouncy Castle module

Refactored ITs, instead of running the ITs once, they now run as part of of the individual module builds
- This ensure the ITs are run for each module (instead of just the first one on the classpath)
- The shared tests are now fall under `main/src/groovy` so they can be included and run from the other modules.