### PR TITLE
Fix parsing timestamps with zone 'Z'

### DIFF
--- a/api/src/main/java/dev/paseto/jpaseto/lang/DateFormats.java
+++ b/api/src/main/java/dev/paseto/jpaseto/lang/DateFormats.java
@@ -31,18 +31,9 @@ public final class DateFormats {
     public static final DateTimeFormatter ISO_OFFSET_DATE_TIME = new DateTimeFormatterBuilder()
                 .parseCaseInsensitive()
                 .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-                .appendOffset("+HH:MM", "+00:00")
+                .appendOffsetId() // append UTC designator "Z"
                 .toFormatter()
                 .withZone(ZoneOffset.UTC);
-
-    // This formatter is identical to the one above, except that it can parse (and generate)
-    // timestamps with 'Z' instead of '+00:00'.
-    private static final DateTimeFormatter ISO_OFFSET_DATE_TIME_Z = new DateTimeFormatterBuilder()
-            .parseCaseInsensitive()
-            .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-            .appendOffsetId()
-            .toFormatter()
-            .withZone(ZoneOffset.UTC);
 
     public static String formatIso8601(Instant instant) {
         return ISO_OFFSET_DATE_TIME.format(instant);
@@ -50,6 +41,6 @@ public final class DateFormats {
 
     public static Instant parseIso8601Date(String s) throws DateTimeException {
         Assert.notNull(s, "String argument cannot be null.");
-        return Instant.from(ISO_OFFSET_DATE_TIME_Z.parse(s));
+        return Instant.from(ISO_OFFSET_DATE_TIME.parse(s));
     }
 }

--- a/api/src/main/java/dev/paseto/jpaseto/lang/DateFormats.java
+++ b/api/src/main/java/dev/paseto/jpaseto/lang/DateFormats.java
@@ -35,12 +35,21 @@ public final class DateFormats {
                 .toFormatter()
                 .withZone(ZoneOffset.UTC);
 
+    // This formatter is identical to the one above, except that it can parse (and generate)
+    // timestamps with 'Z' instead of '+00:00'.
+    private static final DateTimeFormatter ISO_OFFSET_DATE_TIME_Z = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            .appendOffsetId()
+            .toFormatter()
+            .withZone(ZoneOffset.UTC);
+
     public static String formatIso8601(Instant instant) {
         return ISO_OFFSET_DATE_TIME.format(instant);
     }
 
     public static Instant parseIso8601Date(String s) throws DateTimeException {
         Assert.notNull(s, "String argument cannot be null.");
-        return Instant.from(ISO_OFFSET_DATE_TIME.parse(s));
+        return Instant.from(ISO_OFFSET_DATE_TIME_Z.parse(s));
     }
 }

--- a/extensions/json/jackson/src/test/groovy/dev/paseto/jpaseto/io/jackson/JacksonSerializerTest.groovy
+++ b/extensions/json/jackson/src/test/groovy/dev/paseto/jpaseto/io/jackson/JacksonSerializerTest.groovy
@@ -96,7 +96,7 @@ class JacksonSerializerTest {
     @Test
     void testDateTime() {
         DateTimeFormatter dateTimeFormatter = DateFormats.ISO_OFFSET_DATE_TIME
-        def anInstantString = "2019-01-01T00:00:00+00:00"
+        def anInstantString = "2019-01-01T00:00:00Z"
         def dateTime = Instant.from(dateTimeFormatter.parse(anInstantString))
 
         def expected = '{"hello":"' + anInstantString +  '"}'

--- a/impl/src/test/groovy/dev/paseto/jpaseto/impl/DateFormatsTest.groovy
+++ b/impl/src/test/groovy/dev/paseto/jpaseto/impl/DateFormatsTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 jsonwebtoken.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.paseto.jpaseto.impl
+
+import dev.paseto.jpaseto.RequiredTypeException
+import dev.paseto.jpaseto.lang.DateFormats
+import org.hamcrest.MatcherAssert
+import org.testng.annotations.Test
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+
+class DateFormatsTest {
+    @Test
+    void testParseIso8601String() {
+        def d = ZonedDateTime.of(2015, 1, 1, 12, 0, 0, 0, ZoneId.of("UTC")).toInstant()
+        String s = "2015-01-01T12:00:00+00:00"
+        Instant instant = DateFormats.parseIso8601Date(s)
+        assertThat instant, is(d)
+    }
+
+    @Test
+    void testParseIso8601ZString() {
+        def d = ZonedDateTime.of(2015, 1, 1, 12, 0, 0, 0, ZoneId.of("UTC")).toInstant()
+        String s = "2015-01-01T12:00:00Z"
+        Instant instant = DateFormats.parseIso8601Date(s)
+        assertThat instant, is(d)
+    }
+
+    @Test
+    void testFormatDateWithIso8601String() {
+        def d = ZonedDateTime.of(2015, 1, 1, 12, 0, 0, 0, ZoneId.of("UTC")).toInstant()
+        String exp = "2015-01-01T12:00:00+00:00"
+        String s = DateFormats.formatIso8601(d)
+        assertThat s, is(exp)
+    }
+}

--- a/impl/src/test/groovy/dev/paseto/jpaseto/impl/DateFormatsTest.groovy
+++ b/impl/src/test/groovy/dev/paseto/jpaseto/impl/DateFormatsTest.groovy
@@ -47,7 +47,7 @@ class DateFormatsTest {
     @Test
     void testFormatDateWithIso8601String() {
         def d = ZonedDateTime.of(2015, 1, 1, 12, 0, 0, 0, ZoneId.of("UTC")).toInstant()
-        String exp = "2015-01-01T12:00:00+00:00"
+        String exp = "2015-01-01T12:00:00Z"
         String s = DateFormats.formatIso8601(d)
         assertThat s, is(exp)
     }


### PR DESCRIPTION
Since timestamps are defined to be ISO 8601, parsing a 'Z' as timezone
offset should be supported. ~~For compatibility, generating of timestamps is untouched, i.e. still generates zone offsets '+00:00'.~~