### PR TITLE
performance optimization

### DIFF
--- a/api/src/main/java/dev/paseto/jpaseto/PasetoTokenBuilder.java
+++ b/api/src/main/java/dev/paseto/jpaseto/PasetoTokenBuilder.java
@@ -18,7 +18,6 @@ package dev.paseto.jpaseto;
 import java.util.Map;
 
 import dev.paseto.jpaseto.io.Serializer;
-import dev.paseto.jpaseto.lang.Services;
 
 /**
  * A builder interface for creating paseto tokens.
@@ -26,10 +25,14 @@ import dev.paseto.jpaseto.lang.Services;
  * @since 0.1
  * @param <T> A child implementation of PasetoBuilder
  */
-public interface PasetoBuilder<T extends PasetoBuilder> {
-    Serializer<Map<String, Object>> getSerializer();
+public interface PasetoTokenBuilder<T extends PasetoTokenBuilder> extends ClaimsMutator<T> {
+    T setSerializer(Serializer<Map<String, Object>> serializer);
 
-    PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer);
+    byte[] payloadAsBytes();
 
-    String compact(PasetoTokenBuilder t);
+    byte[] footerAsBytes();
+
+    String noPadBase64(byte[]... inputs);
+
+    String footerToString(byte[] footer);
 }

--- a/api/src/main/java/dev/paseto/jpaseto/PasetoV1LocalTokenBuilder.java
+++ b/api/src/main/java/dev/paseto/jpaseto/PasetoV1LocalTokenBuilder.java
@@ -15,21 +15,12 @@
  */
 package dev.paseto.jpaseto;
 
-import java.util.Map;
-
-import dev.paseto.jpaseto.io.Serializer;
-import dev.paseto.jpaseto.lang.Services;
+import javax.crypto.SecretKey;
 
 /**
- * A builder interface for creating paseto tokens.
- * @see Pasetos
+ * A builder for constructing Paseto v1.local tokens.
  * @since 0.1
- * @param <T> A child implementation of PasetoBuilder
  */
-public interface PasetoBuilder<T extends PasetoBuilder> {
-    Serializer<Map<String, Object>> getSerializer();
+public interface PasetoV1LocalTokenBuilder extends PasetoTokenBuilder<PasetoV1LocalTokenBuilder> {
 
-    PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer);
-
-    String compact(PasetoTokenBuilder t);
 }

--- a/api/src/main/java/dev/paseto/jpaseto/PasetoV1PublicTokenBuilder.java
+++ b/api/src/main/java/dev/paseto/jpaseto/PasetoV1PublicTokenBuilder.java
@@ -15,21 +15,12 @@
  */
 package dev.paseto.jpaseto;
 
-import java.util.Map;
-
-import dev.paseto.jpaseto.io.Serializer;
-import dev.paseto.jpaseto.lang.Services;
+import java.security.PrivateKey;
 
 /**
- * A builder interface for creating paseto tokens.
- * @see Pasetos
+ * A builder for constructing Paseto v1.public tokens.
  * @since 0.1
- * @param <T> A child implementation of PasetoBuilder
  */
-public interface PasetoBuilder<T extends PasetoBuilder> {
-    Serializer<Map<String, Object>> getSerializer();
+public interface PasetoV1PublicTokenBuilder extends PasetoTokenBuilder<PasetoV1PublicTokenBuilder> {
 
-    PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer);
-
-    String compact(PasetoTokenBuilder t);
 }

--- a/api/src/main/java/dev/paseto/jpaseto/PasetoV2LocalTokenBuilder.java
+++ b/api/src/main/java/dev/paseto/jpaseto/PasetoV2LocalTokenBuilder.java
@@ -15,21 +15,12 @@
  */
 package dev.paseto.jpaseto;
 
-import java.util.Map;
-
-import dev.paseto.jpaseto.io.Serializer;
-import dev.paseto.jpaseto.lang.Services;
+import javax.crypto.SecretKey;
 
 /**
- * A builder interface for creating paseto tokens.
- * @see Pasetos
+ * A builder for constructing Paseto v2.local tokens.
  * @since 0.1
- * @param <T> A child implementation of PasetoBuilder
  */
-public interface PasetoBuilder<T extends PasetoBuilder> {
-    Serializer<Map<String, Object>> getSerializer();
+public interface PasetoV2LocalTokenBuilder extends PasetoTokenBuilder<PasetoV2LocalTokenBuilder> {
 
-    PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer);
-
-    String compact(PasetoTokenBuilder t);
 }

--- a/api/src/main/java/dev/paseto/jpaseto/PasetoV2PublicTokenBuilder.java
+++ b/api/src/main/java/dev/paseto/jpaseto/PasetoV2PublicTokenBuilder.java
@@ -15,21 +15,12 @@
  */
 package dev.paseto.jpaseto;
 
-import java.util.Map;
-
-import dev.paseto.jpaseto.io.Serializer;
-import dev.paseto.jpaseto.lang.Services;
+import java.security.PrivateKey;
 
 /**
- * A builder interface for creating paseto tokens.
- * @see Pasetos
+ * A builder for constructing Paseto v2.public tokens.
  * @since 0.1
- * @param <T> A child implementation of PasetoBuilder
  */
-public interface PasetoBuilder<T extends PasetoBuilder> {
-    Serializer<Map<String, Object>> getSerializer();
+public interface PasetoV2PublicTokenBuilder extends PasetoTokenBuilder<PasetoV2PublicTokenBuilder> {
 
-    PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer);
-
-    String compact(PasetoTokenBuilder t);
 }

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/AbstractPasetoBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/AbstractPasetoBuilder.java
@@ -15,52 +15,27 @@
  */
 package dev.paseto.jpaseto.impl;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
 import dev.paseto.jpaseto.PasetoBuilder;
+import dev.paseto.jpaseto.PasetoTokenBuilder;
 import dev.paseto.jpaseto.impl.lang.Bytes;
 import dev.paseto.jpaseto.io.Serializer;
 import dev.paseto.jpaseto.lang.Collections;
 import dev.paseto.jpaseto.lang.Services;
 import dev.paseto.jpaseto.lang.Strings;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
-
 abstract class AbstractPasetoBuilder<T extends PasetoBuilder> implements PasetoBuilder<T> {
-
-    private final Map<String, Object> payload = new HashMap<>();
-    private final Map<String, Object> footer = new HashMap<>();
-    private String footerString = null;
-
     private Serializer<Map<String, Object>> serializer;
 
-    @Override
-    public T claim(String key, Object value) {
-        payload.put(key, value);
-        return self();
-    }
-
-    @Override
-    public T footerClaim(String key, Object value) {
-        footer.put(key, value);
-        return self();
-    }
-
-    @Override
-    public T setFooter(String footer) {
-        this.footerString = footer;
-        return self();
-    }
-
-    @SuppressWarnings("unchecked")
-    private T self() {
-        return (T) this;
-    }
-
-    @SuppressWarnings("unchecked")
-    protected Serializer<Map<String, Object>> getSerializer() {
-
+    /**
+     * Returns serializer
+     * @return
+     */
+    public Serializer<Map<String, Object>> getSerializer() {
         // if null just return the first service
         if (serializer == null) {
             return Services.loadFirst(Serializer.class);
@@ -68,52 +43,12 @@ abstract class AbstractPasetoBuilder<T extends PasetoBuilder> implements PasetoB
         return serializer;
     }
 
-    @Override
-    public T setSerializer(Serializer<Map<String, Object>> serializer) {
-        this.serializer = serializer;
-        return self();
-    }
-
-    protected String footerToString(byte[] footer) {
-
-        if (footer == null || footer.length == 0) {
-            return "";
-        }
-
-        return "." + noPadBase64(footer);
-    }
-
-    protected String noPadBase64(byte[]... inputs) {
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(Bytes.concat(inputs));
-    }
-
-    protected byte[] payloadAsBytes() {
-        return getSerializer().serialize(getPayload());
-    }
-
-    protected byte[] footerAsBytes() {
-
-        if (Strings.hasText(getFooterString())) {
-            return getFooterString().getBytes(StandardCharsets.UTF_8);
-        }
-
-        Map<String, Object> tmpFooter = getFooter();
-        if (!Collections.isEmpty(tmpFooter)) {
-            return getSerializer().serialize(tmpFooter);
-        }
-
-        return new byte[0];
-    }
-
-    protected Map<String, Object> getPayload() {
-        return payload;
-    }
-
-    protected Map<String, Object> getFooter() {
-        return footer;
-    }
-
-    protected String getFooterString() {
-        return footerString;
+    /**
+     * Sets serializer and returns original instance of object
+     * @return
+     */
+    public PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer) {
+        this.serializer = newSerializer;
+        return this;
     }
 }

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/AbstractPasetoTokenBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/AbstractPasetoTokenBuilder.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019-Present paseto.dev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.paseto.jpaseto.impl;
+
+import dev.paseto.jpaseto.PasetoTokenBuilder;
+import dev.paseto.jpaseto.impl.lang.Bytes;
+import dev.paseto.jpaseto.io.Serializer;
+import dev.paseto.jpaseto.lang.Collections;
+import dev.paseto.jpaseto.lang.Services;
+import dev.paseto.jpaseto.lang.Strings;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+abstract class AbstractPasetoTokenBuilder<T extends PasetoTokenBuilder> implements PasetoTokenBuilder<T> {
+
+    private final Map<String, Object> payload = new HashMap<>();
+    private final Map<String, Object> footer = new HashMap<>();
+    private String footerString = null;
+
+    private Serializer<Map<String, Object>> serializer;
+
+    @Override
+    public T claim(String key, Object value) {
+        payload.put(key, value);
+        return self();
+    }
+
+    @Override
+    public T footerClaim(String key, Object value) {
+        footer.put(key, value);
+        return self();
+    }
+
+    @Override
+    public T setFooter(String footer) {
+        this.footerString = footer;
+        return self();
+    }
+
+    @SuppressWarnings("unchecked")
+    private T self() {
+        return (T) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Serializer<Map<String, Object>> getSerializer() {
+
+        // if null just return the first service
+        if (serializer == null) {
+            return Services.loadFirst(Serializer.class);
+        }
+        return serializer;
+    }
+
+    @Override
+    public T setSerializer(Serializer<Map<String, Object>> serializer) {
+        this.serializer = serializer;
+        return self();
+    }
+
+    public String footerToString(byte[] footer) {
+
+        if (footer == null || footer.length == 0) {
+            return "";
+        }
+
+        return "." + noPadBase64(footer);
+    }
+
+    public String noPadBase64(byte[]... inputs) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(Bytes.concat(inputs));
+    }
+
+    public byte[] payloadAsBytes() {
+        return getSerializer().serialize(getPayload());
+    }
+
+    public byte[] footerAsBytes() {
+
+        if (Strings.hasText(getFooterString())) {
+            return getFooterString().getBytes(StandardCharsets.UTF_8);
+        }
+
+        Map<String, Object> tmpFooter = getFooter();
+        if (!Collections.isEmpty(tmpFooter)) {
+            return getSerializer().serialize(tmpFooter);
+        }
+
+        return new byte[0];
+    }
+
+    protected Map<String, Object> getPayload() {
+        return payload;
+    }
+
+    protected Map<String, Object> getFooter() {
+        return footer;
+    }
+
+    protected String getFooterString() {
+        return footerString;
+    }
+}

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/CryptoProviders.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/CryptoProviders.java
@@ -23,7 +23,7 @@ import dev.paseto.jpaseto.impl.crypto.V2LocalCryptoProvider;
 import dev.paseto.jpaseto.impl.crypto.V2PublicCryptoProvider;
 import dev.paseto.jpaseto.lang.Services;
 
-class CryptoProviders {
+final class CryptoProviders {
 
     private CryptoProviders() {}
 

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/CryptoProviders.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/CryptoProviders.java
@@ -23,7 +23,7 @@ import dev.paseto.jpaseto.impl.crypto.V2LocalCryptoProvider;
 import dev.paseto.jpaseto.impl.crypto.V2PublicCryptoProvider;
 import dev.paseto.jpaseto.lang.Services;
 
-final class CryptoProviders {
+class CryptoProviders {
 
     private CryptoProviders() {}
 

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoParserBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoParserBuilder.java
@@ -22,6 +22,11 @@ import dev.paseto.jpaseto.PasetoParser;
 import dev.paseto.jpaseto.PasetoParserBuilder;
 import dev.paseto.jpaseto.Purpose;
 import dev.paseto.jpaseto.Version;
+import dev.paseto.jpaseto.impl.crypto.JcaV2PublicCryptoProvider;
+import dev.paseto.jpaseto.impl.crypto.V1LocalCryptoProvider;
+import dev.paseto.jpaseto.impl.crypto.V1PublicCryptoProvider;
+import dev.paseto.jpaseto.impl.crypto.V2LocalCryptoProvider;
+import dev.paseto.jpaseto.impl.crypto.V2PublicCryptoProvider;
 import dev.paseto.jpaseto.io.Deserializer;
 import dev.paseto.jpaseto.lang.Assert;
 import dev.paseto.jpaseto.lang.Services;
@@ -36,6 +41,26 @@ import java.util.function.Predicate;
 
 @AutoService(PasetoParserBuilder.class)
 public class DefaultPasetoParserBuilder implements PasetoParserBuilder {
+
+    private final V1LocalCryptoProvider v1LocalCryptoProvider;
+    private final V2LocalCryptoProvider v2LocalCryptoProvider;
+    private final V1PublicCryptoProvider v1PublicCryptoProvider;
+    private final V2PublicCryptoProvider v2PublicCryptoProvider;
+
+    public DefaultPasetoParserBuilder() {
+        this(CryptoProviders.v1LocalCryptoProvider(), CryptoProviders.v2LocalCryptoProvider(), CryptoProviders.v1PublicCryptoProvider(), CryptoProviders.v2PublicCryptoProvider());
+    }
+
+    private DefaultPasetoParserBuilder(V1LocalCryptoProvider newV1LocalCryptoProvider, V2LocalCryptoProvider newV2LocalCryptoProvider, V1PublicCryptoProvider newV1PublicCryptoProvider, V2PublicCryptoProvider newV2PublicCryptoProvider) {
+        this.v1LocalCryptoProvider = newV1LocalCryptoProvider;
+        this.v2LocalCryptoProvider = newV2LocalCryptoProvider;
+        this.v1PublicCryptoProvider = newV1PublicCryptoProvider;
+        this.v2PublicCryptoProvider = newV2PublicCryptoProvider;
+    }
+
+    public Deserializer<Map<String, Object>> getDeserializer() {
+        return this.deserializer;
+    }
 
     private PublicKey publicKey = null;
     private SecretKey sharedSecret = null;
@@ -91,7 +116,7 @@ public class DefaultPasetoParserBuilder implements PasetoParserBuilder {
                 ? keyResolver
                 : new SimpleKeyResolver(publicKey, sharedSecret);
 
-        return new DefaultPasetoParser(tmpKeyResolver, tmpDeserializer, clock, allowedClockSkew, expectedClaimsMap, expectedFooterClaimsMap);
+        return new DefaultPasetoParser(v1LocalCryptoProvider, v2LocalCryptoProvider, v1PublicCryptoProvider, v2PublicCryptoProvider, tmpKeyResolver, tmpDeserializer, clock, allowedClockSkew, expectedClaimsMap, expectedFooterClaimsMap);
     }
 
 

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV1LocalBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV1LocalBuilder.java
@@ -16,6 +16,8 @@
 package dev.paseto.jpaseto.impl;
 
 import com.google.auto.service.AutoService;
+
+import dev.paseto.jpaseto.PasetoTokenBuilder;
 import dev.paseto.jpaseto.PasetoV1LocalBuilder;
 import dev.paseto.jpaseto.impl.crypto.V1LocalCryptoProvider;
 
@@ -48,10 +50,11 @@ public class DefaultPasetoV1LocalBuilder extends AbstractPasetoBuilder<PasetoV1L
     }
 
     @Override
-    public String compact() {
+    public String compact(PasetoTokenBuilder t) {
+        t.setSerializer(this.getSerializer());
 
-        byte[] payload = payloadAsBytes();
-        byte[] footer = footerAsBytes();
+        byte[] payload = t.payloadAsBytes();
+        byte[] footer = t.footerAsBytes();
 
         // 2
         byte[] randomBytes = new byte[32];
@@ -68,7 +71,7 @@ public class DefaultPasetoV1LocalBuilder extends AbstractPasetoBuilder<PasetoV1L
         byte[] cipherText = cryptoProvider.encrypt(payload, footer, nonce, sharedSecret);
 
         // 8
-        String base64d = noPadBase64(cipherText);
-        return HEADER + base64d + footerToString(footer);
+        String base64d = t.noPadBase64(cipherText);
+        return HEADER + base64d + t.footerToString(footer);
     }
 }

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV1LocalTokenBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV1LocalTokenBuilder.java
@@ -13,23 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.paseto.jpaseto;
+package dev.paseto.jpaseto.impl;
 
-import java.util.Map;
+import com.google.auto.service.AutoService;
+import dev.paseto.jpaseto.PasetoV1LocalTokenBuilder;
 
-import dev.paseto.jpaseto.io.Serializer;
-import dev.paseto.jpaseto.lang.Services;
-
-/**
- * A builder interface for creating paseto tokens.
- * @see Pasetos
- * @since 0.1
- * @param <T> A child implementation of PasetoBuilder
- */
-public interface PasetoBuilder<T extends PasetoBuilder> {
-    Serializer<Map<String, Object>> getSerializer();
-
-    PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer);
-
-    String compact(PasetoTokenBuilder t);
+@AutoService(PasetoV1LocalTokenBuilder.class)
+public class DefaultPasetoV1LocalTokenBuilder extends AbstractPasetoTokenBuilder<PasetoV1LocalTokenBuilder> implements PasetoV1LocalTokenBuilder {
 }

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV1PublicBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV1PublicBuilder.java
@@ -16,6 +16,9 @@
 package dev.paseto.jpaseto.impl;
 
 import com.google.auto.service.AutoService;
+
+import dev.paseto.jpaseto.PasetoTokenBuilder;
+import dev.paseto.jpaseto.PasetoV1LocalBuilder;
 import dev.paseto.jpaseto.PasetoV1PublicBuilder;
 import dev.paseto.jpaseto.impl.crypto.V1PublicCryptoProvider;
 
@@ -45,13 +48,14 @@ public class DefaultPasetoV1PublicBuilder extends AbstractPasetoBuilder<PasetoV1
     }
 
     @Override
-    public String compact() {
+    public String compact(PasetoTokenBuilder t) {
+        t.setSerializer(this.getSerializer());
 
-        byte[] payload = payloadAsBytes();
-        byte[] footer = footerAsBytes();
+        byte[] payload = t.payloadAsBytes();
+        byte[] footer = t.footerAsBytes();
 
         byte[] signature = cryptoProvider.sign(payload, footer, privateKey);
 
-        return HEADER + noPadBase64(payload, signature) + footerToString(footer);
+        return HEADER + t.noPadBase64(payload, signature) + t.footerToString(footer);
     }
 }

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV1PublicTokenBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV1PublicTokenBuilder.java
@@ -13,23 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.paseto.jpaseto;
+package dev.paseto.jpaseto.impl;
 
-import java.util.Map;
+import com.google.auto.service.AutoService;
+import dev.paseto.jpaseto.PasetoV1PublicTokenBuilder;
 
-import dev.paseto.jpaseto.io.Serializer;
-import dev.paseto.jpaseto.lang.Services;
-
-/**
- * A builder interface for creating paseto tokens.
- * @see Pasetos
- * @since 0.1
- * @param <T> A child implementation of PasetoBuilder
- */
-public interface PasetoBuilder<T extends PasetoBuilder> {
-    Serializer<Map<String, Object>> getSerializer();
-
-    PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer);
-
-    String compact(PasetoTokenBuilder t);
+@AutoService(PasetoV1PublicTokenBuilder.class)
+public class DefaultPasetoV1PublicTokenBuilder extends AbstractPasetoTokenBuilder<PasetoV1PublicTokenBuilder> implements PasetoV1PublicTokenBuilder {
 }

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV2LocalBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV2LocalBuilder.java
@@ -16,6 +16,9 @@
 package dev.paseto.jpaseto.impl;
 
 import com.google.auto.service.AutoService;
+
+import dev.paseto.jpaseto.PasetoTokenBuilder;
+import dev.paseto.jpaseto.PasetoV1PublicBuilder;
 import dev.paseto.jpaseto.PasetoV2LocalBuilder;
 import dev.paseto.jpaseto.impl.crypto.V2LocalCryptoProvider;
 
@@ -48,10 +51,11 @@ public class DefaultPasetoV2LocalBuilder extends AbstractPasetoBuilder<PasetoV2L
     }
 
     @Override
-    public String compact() {
+    public String compact(PasetoTokenBuilder t) {
+        t.setSerializer(this.getSerializer());
 
-        byte[] payload = payloadAsBytes();
-        byte[] footer = footerAsBytes();
+        byte[] payload = t.payloadAsBytes();
+        byte[] footer = t.footerAsBytes();
 
         // 2
         byte[] randomBytes = new byte[24];
@@ -67,8 +71,8 @@ public class DefaultPasetoV2LocalBuilder extends AbstractPasetoBuilder<PasetoV2L
         // 4, 5, 6
         byte[] cipherText = cryptoProvider.encrypt(payload, footer, nonce, sharedSecret);
 
-        String base64d = noPadBase64(cipherText);
+        String base64d = t.noPadBase64(cipherText);
 
-        return HEADER + base64d + footerToString(footer);
+        return HEADER + base64d + t.footerToString(footer);
     }
 }

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV2LocalTokenBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV2LocalTokenBuilder.java
@@ -13,23 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.paseto.jpaseto;
+package dev.paseto.jpaseto.impl;
 
-import java.util.Map;
+import com.google.auto.service.AutoService;
+import dev.paseto.jpaseto.PasetoV2LocalTokenBuilder;
 
-import dev.paseto.jpaseto.io.Serializer;
-import dev.paseto.jpaseto.lang.Services;
+@AutoService(PasetoV2LocalTokenBuilder.class)
+public class DefaultPasetoV2LocalTokenBuilder extends AbstractPasetoTokenBuilder<PasetoV2LocalTokenBuilder> implements PasetoV2LocalTokenBuilder {
 
-/**
- * A builder interface for creating paseto tokens.
- * @see Pasetos
- * @since 0.1
- * @param <T> A child implementation of PasetoBuilder
- */
-public interface PasetoBuilder<T extends PasetoBuilder> {
-    Serializer<Map<String, Object>> getSerializer();
-
-    PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer);
-
-    String compact(PasetoTokenBuilder t);
 }

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV2PublicBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV2PublicBuilder.java
@@ -16,6 +16,9 @@
 package dev.paseto.jpaseto.impl;
 
 import com.google.auto.service.AutoService;
+
+import dev.paseto.jpaseto.PasetoTokenBuilder;
+import dev.paseto.jpaseto.PasetoV2LocalBuilder;
 import dev.paseto.jpaseto.PasetoV2PublicBuilder;
 import dev.paseto.jpaseto.impl.crypto.V2PublicCryptoProvider;
 
@@ -45,13 +48,14 @@ public class DefaultPasetoV2PublicBuilder extends AbstractPasetoBuilder<PasetoV2
     }
 
     @Override
-    public String compact() {
+    public String compact(PasetoTokenBuilder t) {
+        t.setSerializer(this.getSerializer());
 
-        byte[] payload = payloadAsBytes();
-        byte[] footer = footerAsBytes();
+        byte[] payload = t.payloadAsBytes();
+        byte[] footer = t.footerAsBytes();
 
         byte[] signature = cryptoProvider.sign(payload, footer, privateKey);
 
-        return HEADER + noPadBase64(payload, signature) + footerToString(footer);
+        return HEADER + t.noPadBase64(payload, signature) + t.footerToString(footer);
     }
 }

--- a/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV2PublicTokenBuilder.java
+++ b/impl/src/main/java/dev/paseto/jpaseto/impl/DefaultPasetoV2PublicTokenBuilder.java
@@ -13,23 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.paseto.jpaseto;
+package dev.paseto.jpaseto.impl;
 
-import java.util.Map;
+import com.google.auto.service.AutoService;
+import dev.paseto.jpaseto.PasetoV2PublicTokenBuilder;
 
-import dev.paseto.jpaseto.io.Serializer;
-import dev.paseto.jpaseto.lang.Services;
+@AutoService(PasetoV2PublicTokenBuilder.class)
+public class DefaultPasetoV2PublicTokenBuilder extends AbstractPasetoTokenBuilder<PasetoV2PublicTokenBuilder> implements PasetoV2PublicTokenBuilder {
 
-/**
- * A builder interface for creating paseto tokens.
- * @see Pasetos
- * @since 0.1
- * @param <T> A child implementation of PasetoBuilder
- */
-public interface PasetoBuilder<T extends PasetoBuilder> {
-    Serializer<Map<String, Object>> getSerializer();
-
-    PasetoBuilder<T> setSerializer(Serializer<Map<String, Object>> newSerializer);
-
-    String compact(PasetoTokenBuilder t);
 }


### PR DESCRIPTION
Current implementation invokes class loading on each token extraction/generation. Which leads to thread locks and poor performance on high scale.
> paseto builder: Improves performance by separating token builder and paseto builder, so paseto builder can be build in advance, and then reused for each token generation
> paseto parser : Boots crypto providers in advance and passes them to parser explicitly